### PR TITLE
Update buildDocs.R

### DIFF
--- a/R/buildDocs.R
+++ b/R/buildDocs.R
@@ -140,7 +140,7 @@ buildDocs <- function(docsLoc, outLoc = NULL, pageList = NULL, optTemplates = NU
       
       secInd <- which(grepl("^### (.*) ###$", b))
       secNames <- gsub("^### (.*) ###$", "\\1", b[secInd])
-      secID <- validID(secNames)
+      secID <- buildDocs:::validID(secNames)
       
       tmp <- paste(sprintf("
       <li class='active'>


### PR DESCRIPTION
Hi Ryan

I found that if I did not do builDocs:::validID, it will get an error saying cannot found validID function.
